### PR TITLE
Updated ports on which FE runs to avoid conflicts with CW BE

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,36 @@ A local environment with:
 docker compose up --build -d
 ```
 
+### Running with fg-cw-backend
+
+When running both the frontend and backend services together, port conflicts have been resolved by:
+
+- Frontend localstack uses port 4567 (mapped to container's internal 4566)
+- Frontend Redis uses port 6380 (mapped to container's internal 6379)
+- Frontend MongoDB uses port 27018 (mapped to container's internal 27017)
+- Frontend app runs on port 3001 (mapped to container's internal 3000)
+
+To run both services:
+
+1. Start the backend first:
+
+```bash
+cd fg-cw-backend
+docker compose up -d
+```
+
+2. Then start the frontend:
+
+```bash
+cd fg-cw-frontend
+docker compose up -d
+```
+
+You can then access:
+
+- Backend API at http://localhost:3000
+- Frontend app at http://localhost:3001
+
 ### Dependabot
 
 We have added an example dependabot configuration file to the repository. You can enable it by renaming

--- a/compose.yml
+++ b/compose.yml
@@ -1,11 +1,9 @@
-version: '3.4'
 services:
-
   localstack:
     image: localstack/localstack:3.0.2
     ports:
-      - '4566:4566' # LocalStack Gateway
-      - '4510-4559:4510-4559' # external services port range
+      - '4567:4566' # Changed from 4566 to 4567
+      # - '4520-4559:4510-4559' # external services port range
     env_file:
       - 'compose/aws.env'
     environment:
@@ -27,7 +25,7 @@ services:
   redis:
     image: redis:7.2.3-alpine3.18
     ports:
-      - '6379:6379'
+      - '6380:6379'
     restart: always
     networks:
       - cdp-tenant
@@ -37,17 +35,17 @@ services:
     networks:
       - cdp-tenant
     ports:
-      - '27017:27017'
+      - '27018:27017'
     volumes:
       - mongodb-data:/data
     restart: always
 
-################################################################################
+  ################################################################################
 
   your-frontend:
     build: ./
     ports:
-      - '3000:3000'
+      - '3001:3000'
     links:
       - 'localstack:localstack'
       - 'redis:redis'


### PR DESCRIPTION
When running both the frontend and backend services together, port conflicts have been resolved by:

- Frontend localstack uses port 4567 (mapped to container's internal 4566)
- Frontend Redis uses port 6380 (mapped to container's internal 6379)
- Frontend MongoDB uses port 27018 (mapped to container's internal 27017)
- Frontend app runs on port 3001 (mapped to container's internal 3000)

To run both services:

1. Start the backend first:

```bash
cd fg-cw-backend
docker compose up -d
```

2. Then start the frontend:

```bash
cd fg-cw-frontend
docker compose up -d
```

You can then access:

- Backend API at http://localhost:3000
- Frontend app at http://localhost:3001