### PR TITLE
FUT-321: Add task list grouped by step on case detail page

### DIFF
--- a/src/server/applications/controller.js
+++ b/src/server/applications/controller.js
@@ -48,10 +48,21 @@ export const applicationsController = {
       return h.response('Case not found').code(404)
     }
 
+    const taskSteps =
+      selectedCase.taskSections?.map((section) => ({
+        heading: section.title,
+        tasks: (section.taskGroups || []).map((group) => ({
+          label: group.title,
+          link: `/cases/${selectedCase.caseRef}/task-group/${group.id}`,
+          status: group.status
+        }))
+      })) || []
+
     return h.view('applications/views/show', {
       pageTitle: 'Case Detail',
       heading: selectedCase.businessName || 'Case Detail',
-      caseData: selectedCase
+      caseData: selectedCase,
+      taskSteps
     })
   }
 }

--- a/src/server/applications/views/show.njk
+++ b/src/server/applications/views/show.njk
@@ -3,6 +3,24 @@
 
 {% block content %}
   <h1 class="govuk-heading-xl govuk-!-margin-bottom-1">Application</h1>
+  {% if taskSteps.length > 0 %}
+    <h2 class="govuk-heading-l govuk-!-margin-top-6">Case Task List</h2>
+
+    {% for step in taskSteps %}
+      <h3 class="govuk-heading-m">{{ loop.index }}. {{ step.heading }}</h3>
+      <ul class="govuk-list govuk-list--bullet">
+        {% for task in step.tasks %}
+          <li>
+            <a href="{{ task.link }}" class="govuk-link">{{ task.label }}</a>
+            <strong class="govuk-tag govuk-tag--grey" style="margin-left: 1rem"
+              >{{ task.status }}</strong
+            >
+          </li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  {% endif %}
+
   <p class="govuk-body govuk-!-margin-top-0">
     Application submitted:
     <strong


### PR DESCRIPTION
- Implemented mapping of taskSections to taskSteps in the applicationsController
- Updated show.njk to render task steps and tasks with appropriate headings, links, and status tags
- Ensured compatibility with existing case data, answers, and action applications display
- Confirmed output aligns with GOV.UK design system styles
