### PR TITLE
Fix/tracing header ref

### DIFF
--- a/src/server/cases/controller.js
+++ b/src/server/cases/controller.js
@@ -201,10 +201,8 @@ export const casesController = {
       return h.response('Case not found').code(404)
     }
 
-    const { nextStage } = request.payload
-
     // call backend with stage update
-    await updateStageAsync(id, nextStage)
+    await updateStageAsync(id)
     // redirect to stage
     return showCase(request, h)
   },

--- a/src/server/cases/controller.js
+++ b/src/server/cases/controller.js
@@ -7,8 +7,8 @@ import { wreck } from '../common/helpers/wreck.js'
 
 const getCases = async () => {
   try {
-    const { data } = await wreck.get('/cases')
-    return data
+    const { payload } = await wreck.get('/cases')
+    return payload.data
   } catch {
     return []
   }
@@ -16,25 +16,26 @@ const getCases = async () => {
 
 const getCaseById = async (caseId) => {
   try {
-    return wreck.get(`/cases/${caseId}`)
+    const { payload } = await wreck.get(`/cases/${caseId}`)
+    return payload
   } catch (error) {
     return null
   }
 }
 
-const updateStageAsync = async (caseId, nextStage) => {
+const updateStageAsync = async (caseId) => {
   try {
-    return wreck.post(`/case/${caseId}/stage`, {
-      payload: { nextStage }
-    })
-  } catch {
+    const { payload } = await wreck.post(`/cases/${caseId}/stage`)
+    return payload
+  } catch (e) {
     return null
   }
 }
 
 const getWorkflowByCode = async (workflowCode) => {
   try {
-    return wreck.get(`/workflows/${workflowCode}`)
+    const { payload } = await wreck.get(`/workflows/${workflowCode}`)
+    return payload
   } catch {
     return null
   }

--- a/src/server/common/helpers/wreck.js
+++ b/src/server/common/helpers/wreck.js
@@ -9,11 +9,11 @@ export const wreck = Wreck.defaults({
   json: true
 })
 
-wreck.events.on('preRequest', (request) => {
+wreck.events.on('preRequest', (uri) => {
   const traceId = getTraceId()
   const tracingHeader = config.get('tracing.header')
 
-  if (traceId && tracingHeader) {
-    request.headers[tracingHeader] = traceId
+  if (traceId) {
+    uri.headers[tracingHeader] = traceId
   }
 })

--- a/src/server/common/helpers/wreck.js
+++ b/src/server/common/helpers/wreck.js
@@ -5,7 +5,8 @@ import { getTraceId } from '@defra/hapi-tracing'
 export const wreck = Wreck.defaults({
   events: true,
   timeout: 3000,
-  baseUrl: config.get('fg_cw_backend_url')
+  baseUrl: config.get('fg_cw_backend_url'),
+  json: true
 })
 
 wreck.events.on('preRequest', (uri) => {

--- a/src/server/common/helpers/wreck.js
+++ b/src/server/common/helpers/wreck.js
@@ -9,10 +9,11 @@ export const wreck = Wreck.defaults({
   json: true
 })
 
-wreck.events.on('preRequest', (uri) => {
+wreck.events.on('preRequest', (request) => {
   const traceId = getTraceId()
+  const tracingHeader = config.get('tracing.header')
 
-  if (traceId) {
-    uri.headers[config.tracingHeader] = traceId
+  if (traceId && tracingHeader) {
+    request.headers[tracingHeader] = traceId
   }
 })


### PR DESCRIPTION
The look up for tracing header in config was incorrect and looking in the wrong place.
This PR fixes this - allowing the traceId to be passed through to the backend.