### PR TITLE
Run against source, fix view resolution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
 node_modules
 Dockerfile
 coverage
+**/*.test.js
+**/__fixtures__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PARENT_VERSION=2.8.4-node22.16.0
+ARG PARENT_VERSION=latest-22
 ARG PORT=3000
 ARG PORT_DEBUG=9229
 
@@ -44,7 +44,7 @@ ARG PARENT_VERSION
 LABEL uk.gov.defra.ffc.parent-image=defradigital/node:${PARENT_VERSION}
 
 COPY --from=production_build /home/node/package*.json ./
-COPY --from=production_build /home/node/.server ./.server/
+COPY --chown=node:node src src
 COPY --from=production_build /home/node/.public/ ./.public/
 COPY --chown=node:node scripts/run.sh scripts/run.sh
 

--- a/compose.yml
+++ b/compose.yml
@@ -8,9 +8,6 @@ services:
     environment:
       PORT: 3000
       NODE_ENV: development
-      REDIS_HOST: redis
-      LOCALSTACK_ENDPOINT: http://localstack:4566
-      USE_SINGLE_INSTANCE_CACHE: true
     networks:
       - cdp-tenant
 

--- a/package.json
+++ b/package.json
@@ -3,15 +3,13 @@
   "version": "0.0.0",
   "description": "FG Caseworking Frontend",
   "sideEffects": false,
-  "main": ".server/main.js",
+  "main": "src/main.js",
   "type": "module",
   "engines": {
     "node": ">=22.14.0"
   },
   "scripts": {
-    "build": "run-s build:frontend build:server",
-    "build:frontend": "NODE_ENV=production webpack",
-    "build:server": "NODE_ENV=production babel --delete-dir-on-start --ignore \"**/*.test.js\" --ignore \"**/test-helpers\" --copy-files --no-copy-ignored --out-dir ./.server ./src",
+    "build": "NODE_ENV=production webpack",
     "dev": "run-p frontend:watch server:watch",
     "dev:debug": "run-p frontend:watch server:debug",
     "format": "prettier --write \"src/**/*.js\" \"**/*.{js,cjs,md,json,config.js,test.js,njk}\"",

--- a/src/common/config.js
+++ b/src/common/config.js
@@ -34,7 +34,7 @@ export const config = convict({
   host: {
     doc: "The host to bind.",
     format: String,
-    default: "localhost",
+    default: "0.0.0.0",
     env: "HOST",
   },
   port: {

--- a/src/common/nunjucks/nunjucks.js
+++ b/src/common/nunjucks/nunjucks.js
@@ -8,13 +8,18 @@ import { formatDate } from "./filters/format-date.js";
 
 const njkPaths = [
   "node_modules/govuk-frontend/dist/",
-  "src/common/components",
   ...(await Array.fromAsync(
     glob(["**/views", "**/*(layouts|components|pages|partials)/"], {
       exclude: ["node_modules", "*.*"],
     }),
   )),
 ];
+
+const viewPaths = await Array.fromAsync(
+  glob(["**/views"], {
+    exclude: ["node_modules", "*.*"],
+  }),
+);
 
 export const environment = Nunjucks.configure(njkPaths, {
   autoescape: true,
@@ -45,11 +50,7 @@ export const nunjucks = {
       environment,
     },
     relativeTo: config.get("root"),
-    path: await Array.fromAsync(
-      glob("**/views", {
-        exclude: ["node_modules", "*.*"],
-      }),
-    ),
+    path: viewPaths,
     isCached: config.get("isProduction"),
     context,
   },


### PR DESCRIPTION
- skip babel and use docker to copy files into the container
- the same paths used to resolve views outside of the container will work inside