### PR TITLE
ask user before overwriting .env on post install set up

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prestart": "npm run build",
     "start": "NODE_ENV=production node --use-strict .",
     "setup:husky": "node -e \"try { (await import('husky')).default() } catch (e) { if (e.code !== 'ERR_MODULE_NOT_FOUND') throw e }\" --input-type module",
-    "setup:env": "cp -n .env.example .env"
+    "setup:env": "cp -i .env.example .env"
   },
   "author": "Defra DDTS",
   "license": "OGL-UK-3.0",


### PR DESCRIPTION
`-i` gives y or n option for overwriting the .env file on post install set up.

![Screenshot 2025-07-09 at 15 37 15](https://github.com/user-attachments/assets/de9a9f84-33ab-42b5-aeb2-90638ab5c801)
