### PR TITLE
fix: add am/pm to date time

### DIFF
--- a/src/cases/routes/__snapshots__/view-timeline.route.test.js.snap
+++ b/src/cases/routes/__snapshots__/view-timeline.route.test.js.snap
@@ -129,7 +129,7 @@ Land Details
                   <p class="timeline__byline">by Julian Kimmings</p>
                 </div>
                 <p class="timeline__date">
-                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01</time>
+                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01 am</time>
                 </p>
                 <div class="timeline__description">
 </div>
@@ -143,7 +143,7 @@ Land Details
                   <p class="timeline__byline">by Julian Kimmings</p>
                 </div>
                 <p class="timeline__date">
-                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01</time>
+                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01 am</time>
                 </p>
                 <div class="timeline__description">
     <p>
@@ -159,7 +159,7 @@ Land Details
                   <p class="timeline__byline">by Nicholai Hel</p>
                 </div>
                 <p class="timeline__date">
-                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01</time>
+                  <time datetime="2025-06-16T09:01:14.072Z">16 Jun 2025 10:01 am</time>
                 </p>
                 <div class="timeline__description">
     <!-- TODO  task link? -->

--- a/src/cases/views/pages/timeline.njk
+++ b/src/cases/views/pages/timeline.njk
@@ -27,7 +27,7 @@
                 </div>
                 <p class="timeline__date">
                   <time datetime="{{ item.createdAt }}"
-                    >{{ item.createdAt | formatDate("d MMM yyyy hh:mm") if item.createdAt }}</time
+                    >{{ item.createdAt | formatDate("d MMM yyyy hh:mm aaa") if item.createdAt }}</time
                   >
                 </p>
                 {{ timelineItemDescription({ data: item.data, eventType: item.eventType }) }}


### PR DESCRIPTION
- quick fix to bring codebase up to date with prototype - adds am/pm to the time for timeline
<img width="729" height="490" alt="Screenshot 2025-07-11 at 09 12 11" src="https://github.com/user-attachments/assets/e4f98122-4616-445e-ab27-5326ba00f148" />
