### PR TITLE
integrate MOJ Frontend Toolkit (v5.1.5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@hapi/vision": "^7.0.3",
         "@hapi/wreck": "^18.1.0",
         "@hapi/yar": "^11.0.2",
+        "@ministryofjustice/frontend": "^5.1.5",
         "aws-embedded-metrics": "^4.2.0",
         "babel-plugin-module-resolver": "^5.0.2",
         "convict": "^6.2.4",
@@ -3076,6 +3077,19 @@
       "license": "MIT",
       "dependencies": {
         "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@ministryofjustice/frontend": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/frontend/-/frontend-5.1.5.tgz",
+      "integrity": "sha512-qplsAEv1+8FeMxrBh+Z9NznX4LjZBTRBZubMlUqWKntBasssz5mp7rF/C8VeiuJhMtfOgB3YYDvxoahSQaoKGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.2.0"
+      },
+      "peerDependencies": {
+        "govuk-frontend": "^5.8.0",
+        "moment": "2.30.1"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -10045,6 +10059,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@hapi/vision": "^7.0.3",
     "@hapi/wreck": "^18.1.0",
     "@hapi/yar": "^11.0.2",
+    "@ministryofjustice/frontend": "^5.1.5",
     "aws-embedded-metrics": "^4.2.0",
     "babel-plugin-module-resolver": "^5.0.2",
     "convict": "^6.2.4",

--- a/src/cases/views/layouts/case-layout.njk
+++ b/src/cases/views/layouts/case-layout.njk
@@ -110,10 +110,13 @@
   </script>
   <script type="module" src="{{ getAssetPath('application.js') }}"></script>
   <script type="module" src="{{ getAssetPath('govuk.js') }}"></script>
+  <script type="module" src="{{ getAssetPath('moj.js') }}"></script>
   <script type="module">
     import { initSelectAllCheckboxes } from "{{ getAssetPath('checkboxes.js') }}";
     import { initAll } from "{{ getAssetPath('govuk.js') }}";
+    import { initAll as initMOJ } from "{{ getAssetPath('moj.js') }}";
     initSelectAllCheckboxes();
     initAll();
+    initMOJ();
   </script>
 {% endblock %}

--- a/src/client/stylesheets/_moj-frontend.scss
+++ b/src/client/stylesheets/_moj-frontend.scss
@@ -1,0 +1,1 @@
+@use "pkg:@ministryofjustice/frontend";

--- a/src/client/stylesheets/application.scss
+++ b/src/client/stylesheets/application.scss
@@ -1,4 +1,5 @@
 @use "govuk-frontend";
+@use "moj-frontend";
 
 @use "variables";
 @use "helpers";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,10 @@ const govukFrontendPath = path.dirname(
   require.resolve("govuk-frontend/package.json"),
 );
 
+const mojFrontendPath = path.dirname(
+  require.resolve("@ministryofjustice/frontend/package.json"),
+);
+
 const ruleTypeAssetResource = "asset/resource";
 
 export default async () => {
@@ -46,6 +50,9 @@ export default async () => {
         import: [
           path.join(govukFrontendPath, "dist/govuk/govuk-frontend.min.js"),
         ],
+      },
+      moj: {
+        import: [path.join(mojFrontendPath, "moj/moj-frontend.min.js")],
       },
       checkboxes: {
         import: ["./javascripts/modules/checkbox-select-all.js"],
@@ -124,6 +131,8 @@ export default async () => {
               options: {
                 sassOptions: {
                   loadPaths: [
+                    ".",
+                    "node_modules",
                     path.join(dirname, "src/client/stylesheets"),
                     ...components,
                   ],
@@ -182,6 +191,10 @@ export default async () => {
         patterns: [
           {
             from: path.join(govukFrontendPath, "dist/govuk/assets"),
+            to: "assets",
+          },
+          {
+            from: path.join(mojFrontendPath, "moj/assets"),
             to: "assets",
           },
           {


### PR DESCRIPTION
- added `@ministryofjustice/frontend` npm package.
- updated Webpack config to load MOJ assets and scripts.
- included MOJ stylesheets in the application (SASS).
- updated `case-layout.njk` to initialize MOJ scripts.