### PR TITLE
ci: fix the build - use node 22 for sonar scan

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,12 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Test Coverage Reports
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
         run: |
+          node -v
           npm ci
           npm run build
           npm test


### PR DESCRIPTION
Fix the build failure reports by ensuring we use node 22+ for the sonar scan.