### PR TITLE
FGP-278 Fix read more line and highlight selected notes

### DIFF
--- a/src/cases/routes/notes/__snapshots__/view-notes.route.test.js.snap
+++ b/src/cases/routes/notes/__snapshots__/view-notes.route.test.js.snap
@@ -275,7 +275,7 @@ Timeline
   </thead>
   <tbody class="govuk-table__body">
     <tr class="govuk-table__row">
-      <td class="govuk-table__cell" data-sort-value="2025-01-01"><a id="note-undefined"></a>01 Jan 2025</td>
+      <td class="govuk-table__cell govuk-table__cell--selected" data-sort-value="2025-01-01"><a id="note-undefined"></a>01 Jan 2025</td>
       <td class="govuk-table__cell">NOTE_ADDED</td>
       <td class="govuk-table__cell wrap-all-text">
 <div data-module="expandable-text" data-truncate-length="100" data-expand-text="read full text">

--- a/src/cases/view-models/notes/view-notes.view-model.js
+++ b/src/cases/view-models/notes/view-notes.view-model.js
@@ -49,21 +49,28 @@ const mapNotes = (notes, selectedNoteRef) => {
         },
       },
     ],
-    rows: notes.map(({ ref, createdAt, createdBy, title, text }) => ({
-      createdAt: {
-        ref,
-        text: formatDate(createdAt, DATE_FORMAT_SHORT_MONTH),
-        sortValue: formatDate(createdAt, DATE_FORMAT_SORTABLE_DATE),
-      },
-      type: { text: title },
-      note: {
-        ref,
-        href: `?selectedNoteRef=${ref}#note-${ref}`,
-        isSelected: ref === selectedNoteRef,
-        text,
-        classes: "wrap-all-text",
-      },
-      addedBy: { text: createdBy },
-    })),
+    rows: notes.map(({ ref, createdAt, createdBy, title, text }) => {
+      const isSelected = ref === selectedNoteRef;
+
+      return {
+        createdAt: {
+          ref,
+          text: formatDate(createdAt, DATE_FORMAT_SHORT_MONTH),
+          classes: isSelected ? "govuk-table__cell--selected" : "",
+          attributes: {
+            "data-sort-value": formatDate(createdAt, DATE_FORMAT_SORTABLE_DATE),
+          },
+        },
+        type: { text: title },
+        note: {
+          ref,
+          href: `?selectedNoteRef=${ref}#note-${ref}`,
+          isSelected,
+          text,
+          classes: "wrap-all-text",
+        },
+        addedBy: { text: createdBy },
+      };
+    }),
   };
 };

--- a/src/cases/view-models/notes/view-notes.view-model.test.js
+++ b/src/cases/view-models/notes/view-notes.view-model.test.js
@@ -75,8 +75,11 @@ describe("createViewNotesViewModel", () => {
     expect(result.data.notes.rows[0]).toEqual({
       createdAt: {
         ref: "note-123",
-        sortValue: "2025-01-01",
         text: "01 Jan 2025",
+        attributes: {
+          "data-sort-value": "2025-01-01",
+        },
+        classes: "govuk-table__cell--selected",
       },
       type: {
         text: "NOTE_ADDED",

--- a/src/cases/views/pages/notes/view-notes.njk
+++ b/src/cases/views/pages/notes/view-notes.njk
@@ -25,9 +25,8 @@
           set row = [
             {
               html: '<a id="note-' + row.createdAt.ref + '"></a>' + row.createdAt.text,
-              attributes: {
-                "data-sort-value": row.createdAt.sortValue
-              }
+              attributes: row.createdAt.attributes,
+              classes: row.createdAt.classes
             },
             row.type,
             {

--- a/src/client/stylesheets/components/table/_table.scss
+++ b/src/client/stylesheets/components/table/_table.scss
@@ -1,5 +1,16 @@
+@use "govuk-frontend" as *;
+
 .govuk-table__cell.wrap-all-text {
   white-space: normal;
   word-break: break-all;
   overflow-wrap: anywhere;
+}
+
+.govuk-table__row:has(.govuk-table__cell.govuk-table__cell--selected) {
+  border-left: 4px solid #00a33b;
+  background-color: govuk-colour("light-grey");
+}
+
+.govuk-table__row:has(.govuk-table__cell.govuk-table__cell--selected) td:first-child {
+  padding-left: 2px;
 }

--- a/src/common/components/expandable-text/__snapshots__/expandable-text.template.test.js.snap
+++ b/src/common/components/expandable-text/__snapshots__/expandable-text.template.test.js.snap
@@ -42,6 +42,7 @@ exports[`expandable-text template > renders truncated text with toggle when text
       hidden
       >This is a very long piece of text that should definitely be truncated because it exceeds the default truncate length of 100 characters and should show a toggle button.</span
     >
+      <br />
       <a
         href="/some-link"
         class="expandable-text__toggle"
@@ -74,6 +75,7 @@ exports[`expandable-text template > renders with correct data attributes 1`] = `
       hidden
       >This text tests that the correct data attributes are set on the container div element.</span
     >
+      <br />
       <a
         href="/data-test"
         class="expandable-text__toggle"
@@ -106,6 +108,7 @@ exports[`expandable-text template > renders with custom linkText and truncateLen
       hidden
       >This text will be truncated at 50 characters because we set a custom truncate length parameter.</span
     >
+      <br />
       <a
         href="/custom-link"
         class="expandable-text__toggle"

--- a/src/common/components/expandable-text/expandable-text.template.njk
+++ b/src/common/components/expandable-text/expandable-text.template.njk
@@ -25,6 +25,7 @@
       >{{ text }}</span
     >
     {% if href %}
+      <br />
       <a
         href="{{ href }}"
         class="expandable-text__toggle"


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-278

- Add `govuk-table__cell--selected` class for selected notes.
- Introduce row highlights with border and background via CSS.

### BEFORE
<img width="974" height="193" alt="image" src="https://github.com/user-attachments/assets/bdc78d81-293d-4be1-985f-b4d4d07f8eef" />


### AFTER
<img width="979" height="384" alt="image" src="https://github.com/user-attachments/assets/f5916b6c-ef1d-48ef-be01-674c5c54f34c" />
