### PR TITLE
FGP-990: update task-detail view model to use statusOption comment

### DIFF
--- a/src/cases/routes/update-task-status.route.js
+++ b/src/cases/routes/update-task-status.route.js
@@ -48,11 +48,16 @@ export const updateTaskStatusRoute = {
 
     const commentFieldName = status ? `${status}-comment` : "comment";
 
+    // find statusOption
+    const statusOption = task.statusOptions?.find((so) => so.code === status);
+    const commentInputDef =
+      statusOption?.commentInputDef ?? task?.commentInputDef;
+
     // Only validate comment if a status option has been selected
-    if (status && !validateComment(task?.commentInputDef, comment)) {
+    if (status && !validateComment(commentInputDef, comment)) {
       errors[commentFieldName] = {
-        text: task?.commentInputDef?.label
-          ? `${task.commentInputDef.label} is required`
+        text: commentInputDef?.label
+          ? `${commentInputDef.label} is required`
           : "Note is required",
         href: `#${commentFieldName}`,
       };

--- a/src/cases/view-models/task-detail.view-model.js
+++ b/src/cases/view-models/task-detail.view-model.js
@@ -89,7 +89,7 @@ export const mapStatusOptions = ({
 
     const conditional = createConditionalTextarea({
       statusCode: option.code,
-      commentInputDef: option.comment ? option.comment : commentInputDef,
+      commentInputDef: option.comment ?? commentInputDef,
       commentText,
       commentError,
     });

--- a/src/cases/view-models/task-detail.view-model.js
+++ b/src/cases/view-models/task-detail.view-model.js
@@ -65,7 +65,7 @@ const getInitialCommentValue = ({
   return "";
 };
 
-const mapStatusOptions = ({
+export const mapStatusOptions = ({
   statusOptions,
   currentStatus,
   commentInputDef,
@@ -89,7 +89,7 @@ const mapStatusOptions = ({
 
     const conditional = createConditionalTextarea({
       statusCode: option.code,
-      commentInputDef,
+      commentInputDef: option.comment ? option.comment : commentInputDef,
       commentText,
       commentError,
     });

--- a/src/cases/view-models/task-detail.view-model.js
+++ b/src/cases/view-models/task-detail.view-model.js
@@ -89,7 +89,7 @@ export const mapStatusOptions = ({
 
     const conditional = createConditionalTextarea({
       statusCode: option.code,
-      commentInputDef: option.comment ?? commentInputDef,
+      commentInputDef: option.commentInputDef ?? commentInputDef,
       commentText,
       commentError,
     });

--- a/src/cases/view-models/task-detail.view-model.test.js
+++ b/src/cases/view-models/task-detail.view-model.test.js
@@ -16,60 +16,7 @@ vi.mock("../../common/helpers/navigation-helpers.js", () => ({
 
 vi.mock("../../common/view-models/header.view-model.js");
 
-describe("createTaskDetailViewModel", () => {
-  const mockRequest = { path: "/cases/case123/tasks/group1/task1" };
-
-  const createMockPage = (caseData) => ({
-    data: caseData,
-    header: { navItems: [] },
-  });
-
-  const mockCaseData = {
-    _id: "case123",
-    caseRef: "REF123",
-    workflowCode: "workflow1",
-    currentPhase: "phase1",
-    currentStage: "stage1",
-    currentStatus: "active",
-    dateReceived: "2024-01-01",
-    assignedUser: "user123",
-    banner: { type: "info", message: "Test banner" },
-    links: [
-      { id: "tasks", text: "Tasks", href: "/tasks" },
-      { id: "details", text: "Details", href: "/details" },
-    ],
-    payload: {
-      submittedAt: "2024-01-01T10:00:00Z",
-      identifiers: { sbi: "SBI123" },
-      answers: { scheme: "Test Scheme" },
-    },
-    stage: {
-      code: "stage1",
-      taskGroups: [
-        {
-          code: "group1",
-          tasks: [
-            {
-              code: "task1",
-              status: "complete",
-              commentRef: "comment1",
-              requiredRoles: { allOf: ["role1"], anyOf: [] },
-              canComplete: true,
-            },
-          ],
-        },
-      ],
-    },
-    comments: [{ ref: "comment1", text: "Test comment" }],
-  };
-
-  const mockQuery = {
-    taskGroupCode: "group1",
-    taskCode: "task1",
-  };
-
-  const mockErrors = { field1: "Error message" };
-
+describe("mapStatusOptions", () => {
   it("should use statusOption comment if it is defined", () => {
     const result = mapStatusOptions({
       statusOptions: [
@@ -161,6 +108,61 @@ describe("createTaskDetailViewModel", () => {
       required: false,
     });
   });
+});
+
+describe("createTaskDetailViewModel", () => {
+  const mockRequest = { path: "/cases/case123/tasks/group1/task1" };
+
+  const createMockPage = (caseData) => ({
+    data: caseData,
+    header: { navItems: [] },
+  });
+
+  const mockCaseData = {
+    _id: "case123",
+    caseRef: "REF123",
+    workflowCode: "workflow1",
+    currentPhase: "phase1",
+    currentStage: "stage1",
+    currentStatus: "active",
+    dateReceived: "2024-01-01",
+    assignedUser: "user123",
+    banner: { type: "info", message: "Test banner" },
+    links: [
+      { id: "tasks", text: "Tasks", href: "/tasks" },
+      { id: "details", text: "Details", href: "/details" },
+    ],
+    payload: {
+      submittedAt: "2024-01-01T10:00:00Z",
+      identifiers: { sbi: "SBI123" },
+      answers: { scheme: "Test Scheme" },
+    },
+    stage: {
+      code: "stage1",
+      taskGroups: [
+        {
+          code: "group1",
+          tasks: [
+            {
+              code: "task1",
+              status: "complete",
+              commentRef: "comment1",
+              requiredRoles: { allOf: ["role1"], anyOf: [] },
+              canComplete: true,
+            },
+          ],
+        },
+      ],
+    },
+    comments: [{ ref: "comment1", text: "Test comment" }],
+  };
+
+  const mockQuery = {
+    taskGroupCode: "group1",
+    taskCode: "task1",
+  };
+
+  const mockErrors = { field1: "Error message" };
 
   it("should create a complete view model", () => {
     const result = createTaskDetailViewModel({

--- a/src/cases/view-models/task-detail.view-model.test.js
+++ b/src/cases/view-models/task-detail.view-model.test.js
@@ -23,7 +23,7 @@ describe("mapStatusOptions", () => {
         {
           code: "complete",
           name: "Complete",
-          comment: {
+          commentInputDef: {
             label: "Option-specific comment",
             helpText: "Option-specific help text",
             mandatory: true,
@@ -75,7 +75,7 @@ describe("mapStatusOptions", () => {
         {
           code: "approved",
           name: "Approved",
-          comment: {
+          commentInputDef: {
             label: "Approval notes",
             helpText: "Explain why approved",
             mandatory: true,

--- a/src/cases/view-models/task-detail.view-model.test.js
+++ b/src/cases/view-models/task-detail.view-model.test.js
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
-import { createTaskDetailViewModel } from "./task-detail.view-model.js";
+import {
+  createTaskDetailViewModel,
+  mapStatusOptions,
+} from "./task-detail.view-model.js";
 
 vi.mock("../../common/helpers/date-helpers.js", () => ({
   getFormattedGBDate: vi.fn((date) => `formatted-${date}`),
@@ -66,6 +69,98 @@ describe("createTaskDetailViewModel", () => {
   };
 
   const mockErrors = { field1: "Error message" };
+
+  it("should use statusOption comment if it is defined", () => {
+    const result = mapStatusOptions({
+      statusOptions: [
+        {
+          code: "complete",
+          name: "Complete",
+          comment: {
+            label: "Option-specific comment",
+            helpText: "Option-specific help text",
+            mandatory: true,
+          },
+        },
+      ],
+      currentStatus: "complete",
+      commentInputDef: {
+        label: "Default comment",
+        helpText: "Default help text",
+        mandatory: false,
+      },
+      currentTaskComment: null,
+      formData: {},
+      errors: {},
+    });
+
+    expect(result[0].conditional).toMatchObject({
+      label: { text: "Option-specific comment" },
+      hint: { text: "Option-specific help text" },
+      required: true,
+    });
+  });
+
+  it("should fallback to commentInputDef when option comment is not defined", () => {
+    const result = mapStatusOptions({
+      statusOptions: [{ code: "complete", name: "Complete" }],
+      currentStatus: "complete",
+      commentInputDef: {
+        label: "Default comment",
+        helpText: "Default help text",
+        mandatory: false,
+      },
+      currentTaskComment: null,
+      formData: {},
+      errors: {},
+    });
+
+    expect(result[0].conditional).toMatchObject({
+      label: { text: "Default comment" },
+      hint: { text: "Default help text" },
+      required: false,
+    });
+  });
+
+  it("should apply comment definitions per status option", () => {
+    const result = mapStatusOptions({
+      statusOptions: [
+        {
+          code: "approved",
+          name: "Approved",
+          comment: {
+            label: "Approval notes",
+            helpText: "Explain why approved",
+            mandatory: true,
+          },
+        },
+        { code: "rejected", name: "Rejected" },
+      ],
+      currentStatus: "approved",
+      commentInputDef: {
+        label: "General comment",
+        helpText: "Optional details",
+        mandatory: false,
+      },
+      currentTaskComment: null,
+      formData: {},
+      errors: {},
+    });
+
+    const approvedOption = result.find((option) => option.value === "approved");
+    const rejectedOption = result.find((option) => option.value === "rejected");
+
+    expect(approvedOption.conditional).toMatchObject({
+      label: { text: "Approval notes" },
+      hint: { text: "Explain why approved" },
+      required: true,
+    });
+    expect(rejectedOption.conditional).toMatchObject({
+      label: { text: "General comment" },
+      hint: { text: "Optional details" },
+      required: false,
+    });
+  });
 
   it("should create a complete view model", () => {
     const result = createTaskDetailViewModel({


### PR DESCRIPTION
- uses optional commentInputDef from statusOptions if it exists, otherwise falls back to the task commentInputDef
- updates validation to also use the statusOption data if it exists, otherwise fall back to task data