### PR TITLE
FGP-1051: remove duplicate "Reason for termination" heading

### DIFF
--- a/src/cases/routes/update-task-status.route.js
+++ b/src/cases/routes/update-task-status.route.js
@@ -1,4 +1,5 @@
 import { setFlashData } from "../../common/helpers/flash-helpers.js";
+import { getLabelText } from "../../common/helpers/string-helpers.js";
 import { logger } from "../../common/logger.js";
 import { findCaseByIdUseCase } from "../use-cases/find-case-by-id.use-case.js";
 import { updateTaskStatusUseCase } from "../use-cases/update-task-status.use-case.js";
@@ -57,7 +58,7 @@ export const updateTaskStatusRoute = {
     if (status && !validateComment(commentInputDef, comment)) {
       errors[commentFieldName] = {
         text: commentInputDef?.label
-          ? `${commentInputDef.label} is required`
+          ? `${getLabelText(commentInputDef.label)} is required`
           : "Note is required",
         href: `#${commentFieldName}`,
       };

--- a/src/cases/use-cases/update-stage-outcome-use.case.js
+++ b/src/cases/use-cases/update-stage-outcome-use.case.js
@@ -1,4 +1,5 @@
 import Boom from "@hapi/boom";
+import { getLabelText } from "../../common/helpers/string-helpers.js";
 import { logger } from "../../common/logger.js";
 import { updateStageOutcome } from "../repositories/case.repository.js";
 import { findCaseByIdUseCase } from "./find-case-by-id.use-case.js";
@@ -54,7 +55,7 @@ export const validateStageOutcomeAction = (caseData, actionData) => {
     success: false,
     errors: {
       [commentFieldName]: {
-        text: `${action.comment.label} is required`,
+        text: `${getLabelText(action.comment.label)} is required`,
         href: `#${commentFieldName}`,
       },
     },

--- a/src/cases/view-models/task-detail.view-model.js
+++ b/src/cases/view-models/task-detail.view-model.js
@@ -1,5 +1,6 @@
 import { setActiveLink } from "../../common/helpers/navigation-helpers.js";
 import { createHeaderViewModel } from "../../common/view-models/header.view-model.js";
+import { createLabelObject } from "./task-list.view-model.js";
 
 const getFieldValue = (fieldName, values) => values?.[fieldName];
 
@@ -25,7 +26,7 @@ const createConditionalTextarea = ({
     id: name,
     name,
     value: commentText,
-    label: { text: commentInputDef.label },
+    label: createLabelObject(commentInputDef.label),
     hint: commentInputDef.helpText
       ? { text: commentInputDef.helpText }
       : undefined,

--- a/src/cases/view-models/task-list.view-model.js
+++ b/src/cases/view-models/task-list.view-model.js
@@ -110,17 +110,16 @@ const getInitialTextareaValue = (action, stage) => {
 
 export const createLabelObject = (label) => {
   if (typeof label === "string") {
-    return {
-      text: label,
-    };
-  } else if (label.text) {
-    return {
-      text: label.text,
-      classes: label.classes,
-    };
-  } else {
-    throw new Error(`Label is not valid '${JSON.stringify(label)}'`);
+    return { text: label };
   }
+  if (isValidLabelObject(label)) {
+    return { text: label.text, classes: label.classes };
+  }
+  throw new Error(`Label is not valid '${JSON.stringify(label)}'`);
+};
+
+const isValidLabelObject = (label) => {
+  return label && typeof label === "object" && "text" in label;
 };
 
 const createTextarea = ({ name, value, comment, errorMessage }) => {

--- a/src/cases/view-models/task-list.view-model.js
+++ b/src/cases/view-models/task-list.view-model.js
@@ -108,12 +108,27 @@ const getInitialTextareaValue = (action, stage) => {
   return isCurrentAction(action, stage) ? stage.outcome?.comment || "" : "";
 };
 
+export const createLabelObject = (label) => {
+  if (typeof label === "string") {
+    return {
+      text: label,
+    };
+  } else if (label.text) {
+    return {
+      text: label.text,
+      classes: label.classes,
+    };
+  } else {
+    throw new Error(`Label is not valid '${JSON.stringify(label)}'`);
+  }
+};
+
 const createTextarea = ({ name, value, comment, errorMessage }) => {
   return {
     id: name,
     name,
     value,
-    label: { text: comment.label },
+    label: createLabelObject(comment.label),
     hint: comment.helpText ? { text: comment.helpText } : undefined,
     required: comment.mandatory,
     errorMessage,

--- a/src/cases/view-models/task-list.view-model.test.js
+++ b/src/cases/view-models/task-list.view-model.test.js
@@ -25,6 +25,23 @@ describe("createLabelObject", () => {
     });
   });
 
+  it("should use label as object with empty string text", () => {
+    expect(createLabelObject({ text: "" })).toEqual({
+      text: "",
+      classes: undefined,
+    });
+  });
+
+  it("should throw if label is null", () => {
+    expect(() => createLabelObject(null)).toThrow("Label is not valid 'null'");
+  });
+
+  it("should throw if label is undefined", () => {
+    expect(() => createLabelObject(undefined)).toThrow(
+      "Label is not valid 'undefined'",
+    );
+  });
+
   it("should throw if label is unknown type", () => {
     expect(() => createLabelObject(true)).toThrow("Label is not valid 'true'");
   });

--- a/src/cases/view-models/task-list.view-model.test.js
+++ b/src/cases/view-models/task-list.view-model.test.js
@@ -1,8 +1,34 @@
 import { describe, expect, it, vi } from "vitest";
 import { createMockLinks } from "../../../test/data/case-test-data.js";
-import { createTaskListViewModel } from "./task-list.view-model.js";
+import {
+  createLabelObject,
+  createTaskListViewModel,
+} from "./task-list.view-model.js";
 
 vi.mock("../../common/view-models/header.view-model.js");
+
+describe("createLabelObject", () => {
+  it("should use label as string", () => {
+    expect(createLabelObject("hello")).toEqual({ text: "hello" });
+  });
+
+  it("should use label as object and ignore invalid props", () => {
+    expect(
+      createLabelObject({
+        text: "goodbye",
+        classes: "one, two",
+        invalid: true,
+      }),
+    ).toEqual({
+      text: "goodbye",
+      classes: "one, two",
+    });
+  });
+
+  it("should throw if label is unknown type", () => {
+    expect(() => createLabelObject(true)).toThrow("Label is not valid 'true'");
+  });
+});
 
 describe("createTaskListViewModel", () => {
   const mockRequest = { path: "/cases/case-123/tasks" };

--- a/src/common/helpers/string-helpers.js
+++ b/src/common/helpers/string-helpers.js
@@ -1,3 +1,6 @@
+export const getLabelText = (label) =>
+  typeof label === "object" ? label.text : label;
+
 export const toStringOrEmpty = (value) => {
   if (value === null || value === undefined) {
     return "";

--- a/src/common/helpers/string-helpers.test.js
+++ b/src/common/helpers/string-helpers.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getLabelText } from "./string-helpers.js";
+
+describe("getLabelText", () => {
+  it("should return a string label as-is", () => {
+    expect(getLabelText("My label")).toBe("My label");
+  });
+
+  it("should return the text property from an object label", () => {
+    expect(getLabelText({ text: "My label", classes: "govuk-label--m" })).toBe(
+      "My label",
+    );
+  });
+
+  it("should return the text property from an object label with empty string", () => {
+    expect(getLabelText({ text: "" })).toBe("");
+  });
+});


### PR DESCRIPTION
- updates the label to allow passing in classes for styling...

Needs: https://github.com/DEFRA/fg-cw-backend/pull/571

https://eaflood.atlassian.net/browse/FGP-1051


<img width="1094" height="1306" alt="Screenshot 2026-05-19 at 13 35 58" src="https://github.com/user-attachments/assets/7d9bd37c-6446-4544-8f19-c9f78472ac59" />
