### PR TITLE
feat(FGP-1179): Removed beforeContent where not needed, and adding afterContent support

### DIFF
--- a/src/cases/routes/__snapshots__/list-tasks.route.test.js.snap
+++ b/src/cases/routes/__snapshots__/list-tasks.route.test.js.snap
@@ -108,6 +108,7 @@ Timeline
   </ul>
 
 
+
   </div>
 </div>
 

--- a/src/cases/routes/tabs/__snapshots__/view-case-tab.route.test.js.snap
+++ b/src/cases/routes/tabs/__snapshots__/view-case-tab.route.test.js.snap
@@ -67,7 +67,6 @@ Tasks
   </div>
 
 
-
   
 
         "
@@ -186,7 +185,6 @@ Agreements
     </div>
 
   </div>
-
 
 
   
@@ -330,7 +328,6 @@ Agreements
     </div>
 
   </div>
-
 
 
   

--- a/src/cases/view-models/task-list.view-model.js
+++ b/src/cases/view-models/task-list.view-model.js
@@ -24,6 +24,7 @@ export const createTaskListViewModel = ({
         actions: mapActions({ stage, errors, values }),
       },
       beforeContent: kase.beforeContent,
+      afterContent: kase.afterContent,
     },
     errors,
     errorList: Object.values(errors),

--- a/src/cases/views/components/task-group/__snapshots__/task-group.template.test.js.snap
+++ b/src/cases/views/components/task-group/__snapshots__/task-group.template.test.js.snap
@@ -50,6 +50,7 @@ exports[`task-group > renders 1`] = `
   </ul>
 
 
+
   </div>
 </div>
 "

--- a/src/cases/views/components/task-group/task-group.template.njk
+++ b/src/cases/views/components/task-group/task-group.template.njk
@@ -24,5 +24,9 @@
     {% if params.stage.actions.items.length > 0 %}
       {{ stageActions({ caseId: params.caseId, stage: params.stage }) }}
     {% endif %}
+
+    {% if params.afterContent %}
+      {{ dynamicContent(params.afterContent) }}
+    {% endif %}
   </div>
 </div>

--- a/src/cases/views/components/task-group/task-group.template.njk
+++ b/src/cases/views/components/task-group/task-group.template.njk
@@ -21,12 +21,12 @@
       {% endfor %}
     {% endif %}
 
-    {% if params.stage.actions.items.length > 0 %}
-      {{ stageActions({ caseId: params.caseId, stage: params.stage }) }}
-    {% endif %}
-
     {% if params.afterContent %}
       {{ dynamicContent(params.afterContent) }}
+    {% endif %}
+
+    {% if params.stage.actions.items.length > 0 %}
+      {{ stageActions({ caseId: params.caseId, stage: params.stage }) }}
     {% endif %}
   </div>
 </div>

--- a/src/cases/views/pages/task-list.njk
+++ b/src/cases/views/pages/task-list.njk
@@ -2,5 +2,5 @@
 {% from "../components/task-group/macro.njk" import taskGroup %}
 
 {% block contentMain %}
-  {{ taskGroup({caseId: data.case._id, stage: data.stage, errors: errors, values: values, beforeContent: data.beforeContent }) }}
+  {{ taskGroup({caseId: data.case._id, stage: data.stage, errors: errors, values: values, beforeContent: data.beforeContent, afterContent: data.afterContent }) }}
 {% endblock %}

--- a/src/cases/views/pages/view-tab.njk
+++ b/src/cases/views/pages/view-tab.njk
@@ -2,9 +2,5 @@
 {% from "../components/dynamic-content/macro.njk" import dynamicContent %}
 
 {% block contentMain %}
-  {% if data.beforeContent %}
-    {{ dynamicContent(data.beforeContent) }}
-  {% endif %}
-
   {{ dynamicContent(data.content) }}
 {% endblock %}


### PR DESCRIPTION
Before content was being pulled into too many places, when it is only related to task pages. It has been removed from the places where it should not be available.

After content support has also been added.

backend PR is here https://github.com/DEFRA/fg-cw-backend/pull/598