### PR TITLE
 FGP-1076: update our repositories to meet the new defra development standards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,20 @@ updates:
     allow:
       - dependency-type: direct
 
+  - package-ecosystem: docker
+    directory: /
+    open-pull-requests-limit: 10
+
+    groups:
+      docker-images:
+        patterns:
+          - "*"
+
+    schedule:
+      interval: weekly
+      time: "10:30"
+      timezone: "Europe/London"
+
   - package-ecosystem: github-actions
     directory: /
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,21 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 git-tag-version=false
+save-exact=true
+ignore-scripts=true
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV PORT=${PORT}
 EXPOSE ${PORT} ${PORT_DEBUG}
 
 COPY --chown=node:node --chmod=755 package*.json ./
+COPY --chown=node:node --chmod=755 .npmrc ./
 RUN npm ci --ignore-scripts
 COPY --chown=node:node --chmod=755 . .
 RUN npm run build
@@ -44,6 +45,7 @@ ARG PARENT_VERSION
 LABEL uk.gov.defra.ffc.parent-image=defradigital/node:${PARENT_VERSION}
 
 COPY --from=production_build /home/node/package*.json ./
+COPY --from=production_build /home/node/.npmrc ./
 COPY --chown=node:node src src
 COPY --from=production_build /home/node/.public/ ./.public/
 COPY --chown=node:node scripts/run.sh scripts/run.sh


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FGP-1076

# FGP-1076: Update fg-cw-frontend to meet the new DEFRA development standards

Config-only changes to align with the DEFRA Node.js, Dependabot and dependency-review standards.

## Changes
- `.github/workflows/dependency-review.yml` — new; blocks vulnerable deps on PRs to `main`, actions SHA-pinned.
- `.github/dependabot.yml` — added the `docker` ecosystem (npm + github-actions already present).
- `.npmrc` — added `save-exact=true`, `ignore-scripts=true`, `min-release-age=7` (kept `git-tag-version=false`).
- `Dockerfile` — copy `.npmrc` before `npm ci` in dev + prod stages so image builds enforce the same npm security controls.

## Notes
- No CI fix needed: vitest supplies env inline, tests run before build, no `pretest` hook.
- Local dev: with `ignore-scripts=true`, run `npm run setup:env` once after install to create `.env`.
- Reviewed (no change): Node v24.14.1 (Active LTS), no TypeScript, ESM, npm + lockfile present.
- OWASP SCP v2.0 review handled separately.
- GHAS dependabot security updates and grouped security updates enabled
