### PR TITLE
Remove redundant `govuk-!-margin-bottom-0` class from case summary template

### DIFF
--- a/src/cases/routes/tabs/__snapshots__/view-case-tab.route.test.js.snap
+++ b/src/cases/routes/tabs/__snapshots__/view-case-tab.route.test.js.snap
@@ -89,25 +89,25 @@ exports[`viewCaseTabRoute > handles different tab types 1`] = `
     <div>
       <div class="app-case-row">
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">SBI:</strong>
                 106284736
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Reference:</strong>
                 10f-f72-e22
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Scheme:</strong>
                 SFI
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Created At:</strong>
                 11 Sept 2025
               </p>
@@ -232,25 +232,25 @@ exports[`viewCaseTabRoute > renders tab view with correct data 1`] = `
     <div>
       <div class="app-case-row">
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">SBI:</strong>
                 106284736
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Reference:</strong>
                 10f-f72-e22
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Scheme:</strong>
                 SFI
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1">Created At:</strong>
                 11 Sept 2025
               </p>

--- a/src/cases/views/components/case-summary/__snapshots__/case-summary.template.test.js.snap
+++ b/src/cases/views/components/case-summary/__snapshots__/case-summary.template.test.js.snap
@@ -66,7 +66,7 @@ exports[`case-summary > renders with callToAction buttons 1`] = `
     <div>
       <div class="app-case-row">
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >SBI:</strong
                 >
@@ -74,7 +74,7 @@ exports[`case-summary > renders with callToAction buttons 1`] = `
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >Reference:</strong
                 >
@@ -104,7 +104,7 @@ exports[`case-summary > renders without callToAction 1`] = `
     <div>
       <div class="app-case-row">
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >SBI:</strong
                 >
@@ -112,7 +112,7 @@ exports[`case-summary > renders without callToAction 1`] = `
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >Reference:</strong
                 >
@@ -120,7 +120,7 @@ exports[`case-summary > renders without callToAction 1`] = `
               </p>
             </div>
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >Scheme:</strong
                 >

--- a/src/cases/views/components/case-summary/case-summary.template.njk
+++ b/src/cases/views/components/case-summary/case-summary.template.njk
@@ -52,7 +52,7 @@
         {% if summary %}
           {% for key, field in summary %}
             <div class="app-case-cell">
-              <p class="govuk-body govuk-!-margin-bottom-0">
+              <p class="govuk-body">
                 <strong class="govuk-!-margin-right-1"
                   >{{ field.label }}:</strong
                 >


### PR DESCRIPTION
BEFORE
<img width="1003" height="146" alt="image" src="https://github.com/user-attachments/assets/24de0c92-3418-43f3-804c-f34e6a875fa1" />

AFTER
<img width="1000" height="152" alt="image" src="https://github.com/user-attachments/assets/82353bd0-0bdf-4e77-ba76-c4d6a249b4dd" />
