### PR TITLE
fix: replace singular commentRef with commentRefs array in task detail view model

### DIFF
--- a/src/cases/view-models/task-detail.view-model.js
+++ b/src/cases/view-models/task-detail.view-model.js
@@ -148,6 +148,10 @@ const buildCurrentTaskData = ({
   };
 };
 
+const findLastCommentRef = (commentRefs, taskStatus) => {
+  return commentRefs?.findLast((cr) => cr.status === taskStatus)?.ref;
+};
+
 export const createTaskDetailViewModel = ({
   page,
   request,
@@ -161,10 +165,11 @@ export const createTaskDetailViewModel = ({
   const { taskGroupCode, taskCode } = query;
 
   const currentTask = findCurrentTask(stage, taskGroupCode, taskCode);
-  const currentTaskComment = findTaskComment(
-    kase.comments,
-    currentTask.commentRef,
+  const currentCommentRef = findLastCommentRef(
+    currentTask.commentRefs,
+    currentTask.status,
   );
+  const currentTaskComment = findTaskComment(kase.comments, currentCommentRef);
   const canComplete = currentTask.canComplete;
   const isInteractive = stage.interactive ?? true;
   const currentStatus = getFieldValue("status", formData) ?? currentTask.status;

--- a/src/cases/view-models/task-detail.view-model.test.js
+++ b/src/cases/view-models/task-detail.view-model.test.js
@@ -519,7 +519,11 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRefs: [{ status: "complete", ref: "comment1" }],
+                commentRefs: [
+                  { status: "in review", ref: "comment2" },
+                  { status: "complete", ref: "comment1" },
+                  { status: "foo", ref: "comment3" },
+                ],
                 statusOptions: [
                   { code: "complete", name: "Complete" },
                   { code: "rejected", name: "Rejected" },
@@ -533,7 +537,11 @@ describe("createTaskDetailViewModel", () => {
           },
         ],
       },
-      comments: [{ ref: "comment1", text: "Existing task comment" }],
+      comments: [
+        { ref: "comment1", text: "Existing task comment" },
+        { ref: "comment2", text: "foo" },
+        { ref: "comment3", text: "comment 3 text" },
+      ],
     };
 
     const result = createTaskDetailViewModel({

--- a/src/cases/view-models/task-detail.view-model.test.js
+++ b/src/cases/view-models/task-detail.view-model.test.js
@@ -146,7 +146,7 @@ describe("createTaskDetailViewModel", () => {
             {
               code: "task1",
               status: "complete",
-              commentRef: "comment1",
+              commentRefs: [{ status: "complete", ref: "comment1" }],
               requiredRoles: { allOf: ["role1"], anyOf: [] },
               canComplete: true,
             },
@@ -234,7 +234,9 @@ describe("createTaskDetailViewModel", () => {
     const caseDataNoComment = structuredClone(mockCaseData);
 
     caseDataNoComment.comments = [];
-    caseDataNoComment.stage.taskGroups[0].tasks[0].commentRef = "nonexistent";
+    caseDataNoComment.stage.taskGroups[0].tasks[0].commentRefs = [
+      { status: "complete", ref: "nonexistent" },
+    ];
 
     const result = createTaskDetailViewModel({
       page: createMockPage(caseDataNoComment),
@@ -407,7 +409,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "in_progress",
-                commentRef: "comment1",
+                commentRefs: [{ ref: "comment1", status: "in_progress" }],
                 requiredRoles: { allOf: ["role1"], anyOf: [] },
                 statusOptions: [
                   { code: "in_progress", name: "In Progress" },
@@ -460,7 +462,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRef: null,
+                commentRefs: null,
                 statusOptions: [
                   { code: "complete", name: "Complete" },
                   { code: "rejected", name: "Rejected" },
@@ -517,7 +519,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRef: "comment1",
+                commentRefs: [{ status: "complete", ref: "comment1" }],
                 statusOptions: [
                   { code: "complete", name: "Complete" },
                   { code: "rejected", name: "Rejected" },
@@ -559,7 +561,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRef: "comment1",
+                commentRefs: [{ status: "complete", ref: "comment1" }],
                 statusOptions: [
                   { code: "complete", name: "Complete" },
                   { code: "rejected", name: "Rejected" },
@@ -601,7 +603,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "in_progress",
-                commentRef: null,
+                commentRefs: null,
                 statusOptions: [
                   { code: "in_progress", name: "In Progress" },
                   { code: "complete", name: "Complete" },
@@ -641,7 +643,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRef: null,
+                commentRefs: null,
                 statusOptions: [],
               },
             ],
@@ -671,7 +673,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "complete",
-                commentRef: null,
+                commentRefs: null,
                 statusOptions: [{ code: "complete", name: "Complete" }],
                 commentInputDef: {
                   label: "Add a comment",
@@ -707,7 +709,7 @@ describe("createTaskDetailViewModel", () => {
               {
                 code: "task1",
                 status: "in_progress",
-                commentRef: null,
+                commentRefs: null,
                 statusOptions: [
                   { code: "in_progress", name: "In Progress" },
                   { code: "complete", name: "Complete" },
@@ -768,7 +770,7 @@ describe("createTaskDetailViewModel", () => {
                 code: "task1",
                 status: "complete",
                 completed: true,
-                commentRef: null,
+                commentRefs: null,
               },
             ],
           },
@@ -798,7 +800,7 @@ describe("createTaskDetailViewModel", () => {
                 {
                   code: "task1",
                   status: "complete",
-                  commentRef: null,
+                  commentRefs: null,
                   notesHistory: [
                     {
                       date: "2025-01-09T10:00:00.000Z",
@@ -847,7 +849,7 @@ describe("createTaskDetailViewModel", () => {
                 {
                   code: "task1",
                   status: "complete",
-                  commentRef: null,
+                  commentRefs: null,
                 },
               ],
             },
@@ -876,7 +878,7 @@ describe("createTaskDetailViewModel", () => {
                 {
                   code: "task1",
                   status: "complete",
-                  commentRef: null,
+                  commentRefs: null,
                   notesHistory: null,
                 },
               ],


### PR DESCRIPTION
The task detail page's "existing note" prefil was broken. 
When a caseworker reopened a task they'd already completed with a note, the note textarea came up empty instead of showing what they'd written (the note still appeared in the notes history, which is built server-side).

Cause: 
`task-detail.view-model.js` looked up the current comment via currentTask.commentRef (singular), but the backend stopped sending that field when it moved to the commentRefs array so the lookup always returned null. The tests didn't catch it because their test data was hard coded as null or a singular element. tasks with the old singular commentRef, a shape the real API never produces, making the assertions pass unintentionally.