### PR TITLE
FGP-1210: Use case SBI for agreement proxy

### DIFF
--- a/src/cases/routes/agreements-proxy.route.test.js
+++ b/src/cases/routes/agreements-proxy.route.test.js
@@ -367,5 +367,31 @@ describe("agreementsProxyRoute", () => {
       });
       expect(mockH.code).toHaveBeenCalledWith(502);
     });
+
+    test("returns 502 when the case has no SBI data", async () => {
+      vi.spyOn(wreck, "get").mockResolvedValue({
+        payload: { data: { workflowCode: "pigs-might-fly" } },
+      });
+      const request = {
+        params: {
+          caseId: "case-123",
+          agreementRef: "PMF823153883",
+        },
+        auth: {
+          credentials: {
+            token: "caseworking-token",
+            user: { id: "caseworker-1" },
+          },
+        },
+      };
+
+      await handler(request, mockH);
+
+      expect(mockH.response).toHaveBeenCalledWith({
+        error: "External Service Unavailable",
+        message: "Unable to process request",
+      });
+      expect(mockH.code).toHaveBeenCalledWith(502);
+    });
   });
 });

--- a/src/cases/routes/agreements-proxy.route.test.js
+++ b/src/cases/routes/agreements-proxy.route.test.js
@@ -301,7 +301,12 @@ describe("agreementsProxyRoute", () => {
 
     test("signs the trusted case workflow code through the composed route", async () => {
       vi.spyOn(wreck, "get").mockResolvedValue({
-        payload: { data: { workflowCode: "pigs-might-fly" } },
+        payload: {
+          data: {
+            workflowCode: "pigs-might-fly",
+            payload: { identifiers: { sbi: "123456789" } },
+          },
+        },
       });
       const request = {
         params: {
@@ -312,7 +317,6 @@ describe("agreementsProxyRoute", () => {
           credentials: {
             token: "caseworking-token",
             user: { id: "caseworker-1" },
-            sbi: "123456789",
           },
         },
         headers: {},

--- a/src/cases/use-cases/proxy-to-agreements.use-case.js
+++ b/src/cases/use-cases/proxy-to-agreements.use-case.js
@@ -42,11 +42,12 @@ const buildTargetUri = function (baseUrl, path) {
 /**
  * Adds the Agreements UI JWT authentication header.
  * @param {object} headers - The proxy headers
- * @param {string|undefined} sbi - The agreement owner's SBI
- * @param {string|undefined} grantCode - Trusted case workflow code
+ * @param {{sbi?: string, grantCode?: string}} trustedClaims - Trusted agreement claims
  * @returns {object} The proxy headers
  */
-const addJwtHeader = function (headers, sbi, grantCode) {
+const addJwtHeader = (headers, trustedClaims) => {
+  const { sbi, grantCode } = trustedClaims;
+
   try {
     // Always generate JWT for 'entra' source (SBI is optional)
     headers["x-encrypted-auth"] = generateAgreementsJwt(sbi, grantCode);
@@ -57,7 +58,7 @@ const addJwtHeader = function (headers, sbi, grantCode) {
   return headers;
 };
 
-const buildProxyHeaders = function (uiToken, request, sbi, grantCode) {
+const buildProxyHeaders = (uiToken, request, trustedClaims) => {
   const headers = {
     Authorization: `Bearer ${uiToken}`,
     "x-base-url": config.get("agreements.baseUrl"),
@@ -67,7 +68,7 @@ const buildProxyHeaders = function (uiToken, request, sbi, grantCode) {
     "X-Correlation-ID": request.headers["x-correlation-id"] || request.info.id,
   };
 
-  return addJwtHeader(headers, sbi, grantCode);
+  return addJwtHeader(headers, trustedClaims);
 };
 
 /**
@@ -83,16 +84,17 @@ export const getAgreementsBaseUrl = function () {
  * @param {object} options - Proxy request options
  * @param {string} options.path - The path to proxy
  * @param {object} options.request - The incoming request
- * @param {string|undefined} options.sbi - Trusted agreement owner SBI
- * @param {string|undefined} options.grantCode - Trusted case workflow code
+ * @param {{sbi?: string, grantCode?: string}} [options.trustedClaims] - Trusted agreement claims
  * @returns {{uri: string, headers: object}}
  */
-export const proxyToAgreements = ({ path, request, sbi, grantCode }) => {
+export const proxyToAgreements = ({ path, request, trustedClaims }) => {
   const { uiUrl, uiToken } = validateConfig();
   const uri = buildTargetUri(uiUrl, path);
-  const agreementSbi = sbi || request.auth.credentials.sbi;
+  const agreementClaims = trustedClaims ?? {
+    sbi: request.auth.credentials.sbi,
+  };
   logger.info(`Proxying request to agreements UI: ${uri} and path: ${path}`);
-  const headers = buildProxyHeaders(uiToken, request, agreementSbi, grantCode);
+  const headers = buildProxyHeaders(uiToken, request, agreementClaims);
 
   logger.info(
     `Finished: Proxying request to agreements UI: ${uri} and path: ${path}`,
@@ -113,23 +115,28 @@ const getWorkflowCode = (page) => {
   return workflowCode;
 };
 
+const getCaseIdentifiers = (page) => page?.data?.payload?.identifiers;
+
 const getCaseSbi = (page) => {
-  const sbi = page.data.payload.identifiers.sbi;
+  const sbi = getCaseIdentifiers(page)?.sbi;
   if (!sbi) {
     throw Boom.badGateway("Case SBI is unavailable");
   }
   return sbi;
 };
 
+const getTrustedClaims = (page) => ({
+  grantCode: getWorkflowCode(page),
+  sbi: getCaseSbi(page),
+});
+
 export const proxyCaseAgreement = async (caseId, agreementRef, request) => {
   const page = await findCaseByIdUseCase(getAuthContext(request), caseId);
-  const grantCode = getWorkflowCode(page);
-  const sbi = getCaseSbi(page);
+  const trustedClaims = getTrustedClaims(page);
 
   return proxyToAgreements({
     path: agreementRef,
     request,
-    sbi,
-    grantCode,
+    trustedClaims,
   });
 };

--- a/src/cases/use-cases/proxy-to-agreements.use-case.js
+++ b/src/cases/use-cases/proxy-to-agreements.use-case.js
@@ -42,14 +42,11 @@ const buildTargetUri = function (baseUrl, path) {
 /**
  * Adds the Agreements UI JWT authentication header.
  * @param {object} headers - The proxy headers
- * @param {object} request - The incoming request
+ * @param {string|undefined} sbi - The agreement owner's SBI
  * @param {string|undefined} grantCode - Trusted case workflow code
  * @returns {object} The proxy headers
  */
-// eslint-disable-next-line complexity
-const addJwtHeader = function (headers, request, grantCode) {
-  const sbi = request?.auth?.credentials?.sbi;
-
+const addJwtHeader = function (headers, sbi, grantCode) {
   try {
     // Always generate JWT for 'entra' source (SBI is optional)
     headers["x-encrypted-auth"] = generateAgreementsJwt(sbi, grantCode);
@@ -60,7 +57,7 @@ const addJwtHeader = function (headers, request, grantCode) {
   return headers;
 };
 
-const buildProxyHeaders = function (uiToken, request, grantCode) {
+const buildProxyHeaders = function (uiToken, request, sbi, grantCode) {
   const headers = {
     Authorization: `Bearer ${uiToken}`,
     "x-base-url": config.get("agreements.baseUrl"),
@@ -70,7 +67,7 @@ const buildProxyHeaders = function (uiToken, request, grantCode) {
     "X-Correlation-ID": request.headers["x-correlation-id"] || request.info.id,
   };
 
-  return addJwtHeader(headers, request, grantCode);
+  return addJwtHeader(headers, sbi, grantCode);
 };
 
 /**
@@ -86,14 +83,16 @@ export const getAgreementsBaseUrl = function () {
  * @param {object} options - Proxy request options
  * @param {string} options.path - The path to proxy
  * @param {object} options.request - The incoming request
+ * @param {string|undefined} options.sbi - Trusted agreement owner SBI
  * @param {string|undefined} options.grantCode - Trusted case workflow code
  * @returns {{uri: string, headers: object}}
  */
-export const proxyToAgreements = ({ path, request, grantCode }) => {
+export const proxyToAgreements = ({ path, request, sbi, grantCode }) => {
   const { uiUrl, uiToken } = validateConfig();
   const uri = buildTargetUri(uiUrl, path);
+  const agreementSbi = sbi || request.auth.credentials.sbi;
   logger.info(`Proxying request to agreements UI: ${uri} and path: ${path}`);
-  const headers = buildProxyHeaders(uiToken, request, grantCode);
+  const headers = buildProxyHeaders(uiToken, request, agreementSbi, grantCode);
 
   logger.info(
     `Finished: Proxying request to agreements UI: ${uri} and path: ${path}`,
@@ -114,11 +113,23 @@ const getWorkflowCode = (page) => {
   return workflowCode;
 };
 
+const getCaseSbi = (page) => {
+  const sbi = page.data.payload.identifiers.sbi;
+  if (!sbi) {
+    throw Boom.badGateway("Case SBI is unavailable");
+  }
+  return sbi;
+};
+
 export const proxyCaseAgreement = async (caseId, agreementRef, request) => {
   const page = await findCaseByIdUseCase(getAuthContext(request), caseId);
+  const grantCode = getWorkflowCode(page);
+  const sbi = getCaseSbi(page);
+
   return proxyToAgreements({
     path: agreementRef,
     request,
-    grantCode: getWorkflowCode(page),
+    sbi,
+    grantCode,
   });
 };

--- a/src/cases/use-cases/proxy-to-agreements.use-case.test.js
+++ b/src/cases/use-cases/proxy-to-agreements.use-case.test.js
@@ -175,4 +175,31 @@ describe("proxyCaseAgreement", () => {
       output: { statusCode: 502 },
     });
   });
+
+  test.each([
+    ["payload", { data: { workflowCode: "pigs-might-fly" } }],
+    ["identifiers", { data: { workflowCode: "pigs-might-fly", payload: {} } }],
+    [
+      "SBI",
+      {
+        data: {
+          workflowCode: "pigs-might-fly",
+          payload: { identifiers: {} },
+        },
+      },
+    ],
+  ])("fails when the case %s is unavailable", async (_field, page) => {
+    findCaseByIdUseCase.mockResolvedValue(page);
+
+    await expect(
+      proxyUseCase.proxyCaseAgreement(
+        "case-123",
+        "PMF823153883",
+        createRequest({ token: "caseworking-token", user: {} }),
+      ),
+    ).rejects.toMatchObject({
+      message: "Case SBI is unavailable",
+      output: { statusCode: 502 },
+    });
+  });
 });

--- a/src/cases/use-cases/proxy-to-agreements.use-case.test.js
+++ b/src/cases/use-cases/proxy-to-agreements.use-case.test.js
@@ -131,12 +131,14 @@ describe("proxyCaseAgreement", () => {
 
   test("uses the trusted case workflow code in the Agreements JWT", async () => {
     findCaseByIdUseCase.mockResolvedValue({
-      data: { workflowCode: "pigs-might-fly" },
+      data: {
+        workflowCode: "pigs-might-fly",
+        payload: { identifiers: { sbi: "123456789" } },
+      },
     });
     const request = createRequest({
       token: "caseworking-token",
       user: { id: "caseworker-1" },
-      sbi: "123456789",
     });
 
     const result = await proxyUseCase.proxyCaseAgreement(


### PR DESCRIPTION
## Problem

Caseworking agreement requests were signing the Agreements UI JWT with the SBI from the caseworker credentials rather than the agreement owner SBI held on the case.

## Changes

- read the trusted SBI from the fetched case payload
- pass the case SBI into Agreements UI JWT generation
- return a bad gateway response when the case SBI is unavailable
- update route and use-case tests

## Jira

[FGP-1210](https://eaflood.atlassian.net/browse/FGP-1210)

## Checks

- `npm run format:check`
- `npm run lint`
- `npm test` (131 files, 828 tests)

## Manual checks

- Not run; covered by route and use-case tests.

[FGP-1210]: https://eaflood.atlassian.net/browse/FGP-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ