### PR TITLE
FGP-1307: add exp, iss, aud and sub claims to caseworker agreement token

### DIFF
--- a/src/common/helpers/agreements-jwt.js
+++ b/src/common/helpers/agreements-jwt.js
@@ -2,6 +2,17 @@ import Jwt from "@hapi/jwt";
 import { config } from "../config.js";
 import { logger } from "../logger.js";
 
+// FGP-1307: caller-token hardening. These registered claims are added so that
+// Agreements UI and GAS can verify the caller token (issuer, audience, subject
+// and a short expiry). They are additive - consumers validate them in a
+// backwards-compatible ("warn-only") mode until enforcement lands.
+const TOKEN_ISSUER = "fg-cw-frontend";
+// Interim: one token is accepted by both Agreements UI and GAS. This will be
+// replaced by token exchange (a per-target audience) later.
+const TOKEN_AUDIENCE = ["agreements-ui", "gas"];
+// Five-minute expiry; a fresh token is minted per authenticated request.
+const TOKEN_TTL_SECONDS = 300;
+
 /**
  * Generates a JWT token for agreements authentication
  * @param {string|number|undefined} sbi - The SBI (Single Business Identifier), optional for 'entra' source
@@ -10,13 +21,18 @@ import { logger } from "../logger.js";
  * @throws {Error} If JWT generation fails
  */
 const buildJwtPayload = function (sbi, grantCode) {
-  const payload = { source: "entra" };
+  const payload = {
+    source: "entra",
+    iss: TOKEN_ISSUER,
+    aud: TOKEN_AUDIENCE,
+  };
   if (sbi != null) {
     payload.sbi = sbi.toString();
   }
   if (grantCode) {
     payload.grantCode = grantCode;
   }
+  payload.sub = payload.sbi ?? TOKEN_ISSUER;
   return payload;
 };
 
@@ -29,7 +45,9 @@ export const generateAgreementsJwt = function (sbi, grantCode) {
 
   try {
     const payload = buildJwtPayload(sbi, grantCode);
-    return Jwt.token.generate(payload, jwtSecret);
+    return Jwt.token.generate(payload, jwtSecret, {
+      ttlSec: TOKEN_TTL_SECONDS,
+    });
   } catch (error) {
     logger.error("Failed to generate agreements JWT", { error: error.message });
     throw new Error(`Failed to generate JWT token: ${error.message}`);

--- a/src/common/helpers/agreements-jwt.test.js
+++ b/src/common/helpers/agreements-jwt.test.js
@@ -44,6 +44,31 @@ describe("generateAgreementsJwt", () => {
     expect(payload.grantCode).toBeUndefined();
   });
 
+  test("should include FGP-1307 hardened claims (iss, aud, sub, exp)", async () => {
+    const { generateAgreementsJwt } = await import("./agreements-jwt.js");
+    const before = Math.floor(Date.now() / 1000);
+    const token = generateAgreementsJwt("123456789", "soil-improvement");
+
+    const parts = token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64").toString());
+
+    expect(payload.iss).toBe("fg-cw-frontend");
+    expect(payload.aud).toEqual(["agreements-ui", "gas"]);
+    expect(payload.sub).toBe("123456789");
+    expect(payload.exp).toBeGreaterThanOrEqual(before + 300);
+    expect(payload.exp).toBeLessThanOrEqual(before + 300 + 5);
+  });
+
+  test("should fall back to the issuer as subject when no SBI is present", async () => {
+    const { generateAgreementsJwt } = await import("./agreements-jwt.js");
+    const token = generateAgreementsJwt(undefined);
+
+    const parts = token.split(".");
+    const payload = JSON.parse(Buffer.from(parts[1], "base64").toString());
+
+    expect(payload.sub).toBe("fg-cw-frontend");
+  });
+
   test("should include configured grant code alongside existing claims", async () => {
     const { generateAgreementsJwt } = await import("./agreements-jwt.js");
     const token = generateAgreementsJwt("123456789", "soil-improvement");


### PR DESCRIPTION
[Jira](https://eaflood.atlassian.net/jira/software/c/projects/FGP/boards/7369?assignee=712020%3Ad3a1613c-562f-4be3-b120-155b9dd1a914&quickFilter=17085&selectedIssue=FGP-1307)

The Caseworking frontend mints the caller token (x-encrypted-auth) it sends to Agreements UI / GAS. 
Previously that token carried no registered claims, so downstream services couldn't validate who issued it, who it was for, or when it expires. This PR adds the hardened claims so Agreements UI and GAS can verify the caller token.

What's included
• Adds registered claims to the generated JWT in src/common/helpers/agreements-jwt.js:
◦ iss: 'fg-cw-frontend' — this service is the token issuer
◦ aud: ['agreements-ui', 'gas'] — both current validators (interim; token exchange / per-target audience comes later)
◦ sub — the caller's SBI, falling back to the issuer name when no SBI is present
◦ exp — 5-minute expiry (ttlSec: 300), a fresh token per authenticated request
• Unit tests covering the new claims and the sub fallback.

Notes
• Backwards-compatible: this only adds claims to a token that was already valid; existing consumers that ignore them are unaffected.
• Part of the FGP-1307 top three auth issues caller-auth hardening (producer side). Pairs with the GAS/Agreements-UI validation PRs, but can merge independently.
• aud/iss values are the agreed identifiers matched by GAS (gas) and Agreements UI (agreements-ui); signing continues to use the shared AGREEMENTS_JWT_SECRET.

Follow-ups (out of scope here)
• Header rename: the caller token travels in x-encrypted-auth, a misleading name (the token is signed, not encrypted). A future ticket may rename it; this service writes that header and would be updated as part of that change.
• Enforcement: validators are warn-only for now. A later ticket turns the claim/signature checks into hard rejections and removes the legacy x-agreement- trust path.
• Query-string token deprecation is handled in the Agreements UI repo (not here) — CW only ever sends the token as a header.

Clarifying comments  left in at this stage during backwards compatibility